### PR TITLE
Update production host references to chatbot.auto-atendimento.digital

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -22,9 +22,10 @@ python run.py
 
 ## 🌐 Acessos
 
-- **Interface Web**: http://localhost:8000
-- **API Docs**: http://localhost:8000/api/docs  
-- **Baileys Service**: http://localhost:3001
+- **Interface Web**: http://chatbot.auto-atendimento.digital:8000
+- **API Docs**: http://chatbot.auto-atendimento.digital:8000/api/docs
+- **Baileys Service**: http://chatbot.auto-atendimento.digital:3001
+- **IP do Servidor**: 78.46.250.112
 
 ## 👤 Login Padrão
 
@@ -34,7 +35,7 @@ python run.py
 
 ## 📱 Como Conectar WhatsApp
 
-1. Acesse http://localhost:8000
+1. Acesse http://chatbot.auto-atendimento.digital:8000
 2. Faça login com admin/admin123
 3. Vá em "Números Conectados"
 4. Clique "Conectar Número"
@@ -143,7 +144,7 @@ Se encontrar problemas:
 
 1. Verifique os logs: `docker-compose logs -f`
 2. Consulte a documentação completa: `/app/README.md`
-3. Verifique a API: http://localhost:8000/api/docs
+3. Verifique a API: http://chatbot.auto-atendimento.digital:8000/api/docs
 
 ## 🎉 Sucesso!
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ docker-compose up -d
 ```
 
 4. **Acesse a aplicação**:
-- Interface Web: http://localhost:8000
-- API Docs: http://localhost:8000/api/docs
-- Baileys Service: http://localhost:3001
+- Interface Web: http://chatbot.auto-atendimento.digital:8000
+- API Docs: http://chatbot.auto-atendimento.digital:8000/api/docs
+- Baileys Service: http://chatbot.auto-atendimento.digital:3001
+- IP do Servidor: 78.46.250.112
 
 ### Instalação Manual
 
@@ -130,7 +131,7 @@ npm start
 
 ### 1. Primeiro Acesso
 
-Após a instalação, acesse http://localhost:8000 e faça login com:
+Após a instalação, acesse http://chatbot.auto-atendimento.digital:8000 e faça login com:
 - **Usuário**: admin
 - **Senha**: admin123
 
@@ -175,8 +176,8 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 
 # Services
-BAILEYS_API_URL=http://localhost:3001
-FRONTEND_URL=http://localhost:8000
+BAILEYS_API_URL=http://chatbot.auto-atendimento.digital:3001
+FRONTEND_URL=http://chatbot.auto-atendimento.digital:8000
 ```
 
 ### Banco de Dados

--- a/config.py
+++ b/config.py
@@ -7,8 +7,8 @@ class Settings(BaseSettings):
     secret_key: str
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 30
-    baileys_api_url: str = "http://localhost:3001"
-    frontend_url: str = "http://localhost:8000"
+    baileys_api_url: str = "http://chatbot.auto-atendimento.digital:3001"
+    frontend_url: str = "http://chatbot.auto-atendimento.digital:8000"
     
     class Config:
         env_file = ".env"

--- a/run.py
+++ b/run.py
@@ -53,9 +53,9 @@ def run_with_docker():
         
         print("✅ Sistema iniciado com Docker!")
         print("\n📋 Serviços disponíveis:")
-        print("  🌐 Frontend: http://localhost:8000")
-        print("  📚 API Docs: http://localhost:8000/api/docs")
-        print("  🤖 Baileys: http://localhost:3001")
+        print("  🌐 Frontend: http://chatbot.auto-atendimento.digital:8000")
+        print("  📚 API Docs: http://chatbot.auto-atendimento.digital:8000/api/docs")
+        print("  🤖 Baileys: http://chatbot.auto-atendimento.digital:3001")
         print("  🗄️  PostgreSQL: localhost:5432")
         print("  🔴 Redis: localhost:6379")
         
@@ -124,9 +124,9 @@ def run_development():
         
         print("✅ Sistema iniciado em modo desenvolvimento!")
         print("\n📋 Serviços disponíveis:")
-        print("  🌐 Frontend: http://localhost:8000")
-        print("  📚 API Docs: http://localhost:8000/api/docs")
-        print("  🤖 Baileys: http://localhost:3001")
+        print("  🌐 Frontend: http://chatbot.auto-atendimento.digital:8000")
+        print("  📚 API Docs: http://chatbot.auto-atendimento.digital:8000/api/docs")
+        print("  🤖 Baileys: http://chatbot.auto-atendimento.digital:3001")
         
         print("\n⚠️  Certifique-se de que PostgreSQL e Redis estão rodando!")
         print("  PostgreSQL: localhost:5432")

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -59,7 +59,7 @@ fi
 
 # Start the application
 print_status "Starting FastAPI application..."
-print_status "API Documentation will be available at: http://localhost:8000/api/docs"
-print_status "Main Application will be available at: http://localhost:8000"
+print_status "API Documentation will be available at: http://chatbot.auto-atendimento.digital:8000/api/docs"
+print_status "Main Application will be available at: http://chatbot.auto-atendimento.digital:8000"
 
 exec uvicorn main:app --host 0.0.0.0 --port 8000 --reload --log-level info


### PR DESCRIPTION
## Summary
- point default FastAPI settings to chatbot.auto-atendimento.digital instead of localhost
- update helper scripts and documentation to advertise the new domain and server IP

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca0345d3e4832b9231223f7e88207c