### PR TITLE
Update configuration to target 78.46.250.112 host

### DIFF
--- a/CORRIGIR.md
+++ b/CORRIGIR.md
@@ -61,7 +61,7 @@ python3 -m uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 
 ```bash
 # Testar API
-curl http://chatbot.auto-atendimento.digital:8000/health
+curl http://78.46.250.112:8000/health
 
 # Testar se módulos foram instalados
 python3 -c "import fastapi, sqlalchemy, psycopg2; print('✅ Dependências OK')"
@@ -105,7 +105,7 @@ chmod +x *.py
 ## 🎯 RESULTADO ESPERADO
 
 Após correção, você deve conseguir:
-- ✅ Acessar http://chatbot.auto-atendimento.digital:8000
+- ✅ Acessar http://78.46.250.112:8000
 - ✅ Ver a interface de login
 - ✅ Fazer login com admin/admin123
 - ✅ Acessar todas as funcionalidades

--- a/EXECUTAR.md
+++ b/EXECUTAR.md
@@ -28,9 +28,9 @@ python3 main.py
 
 ## 🌐 ACESSOS
 
-- **🖥️ Interface Principal**: http://chatbot.auto-atendimento.digital:8000
-- **📚 Documentação da API**: http://chatbot.auto-atendimento.digital:8000/api/docs
-- **🤖 Baileys API**: http://chatbot.auto-atendimento.digital:3001
+- **🖥️ Interface Principal**: http://78.46.250.112:8000
+- **📚 Documentação da API**: http://78.46.250.112:8000/api/docs
+- **🤖 Baileys API**: http://78.46.250.112:3001
 
 ## 👤 LOGIN PADRÃO
 
@@ -41,7 +41,7 @@ python3 main.py
 
 ## 📱 CONECTAR WHATSAPP
 
-1. Acesse http://chatbot.auto-atendimento.digital:8000
+1. Acesse http://78.46.250.112:8000
 2. Faça login com admin/admin123
 3. Vá em **"Números Conectados"**
 4. Clique **"Conectar Número"**
@@ -67,7 +67,7 @@ ps aux | grep -E "(uvicorn|node)"
 tail -f /var/log/syslog | grep whatsapp
 
 # Testar API
-curl http://chatbot.auto-atendimento.digital:8000/health
+curl http://78.46.250.112:8000/health
 ```
 
 ## 🚨 TROUBLESHOOTING

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Sistema completo de gestão de bots WhatsApp com auto-instalação**
 
-🌐 **Domínio**: chatbot.auto-atendimento.digital  
+🌐 **Domínio**: 78.46.250.112  
 🖥️ **Servidor**: 78.46.250.112
 
 ## ⚡ INSTALAÇÃO E EXECUÇÃO EM 1 COMANDO
@@ -21,9 +21,9 @@ python3 main.py
 
 ## 🌐 Acessos
 
-- **Interface Web**: http://chatbot.auto-atendimento.digital:8000
-- **API Docs**: http://chatbot.auto-atendimento.digital:8000/api/docs
-- **Baileys API**: http://chatbot.auto-atendimento.digital:3001
+- **Interface Web**: http://78.46.250.112:8000
+- **API Docs**: http://78.46.250.112:8000/api/docs
+- **Baileys API**: http://78.46.250.112:3001
 
 ## 👤 Login Padrão
 
@@ -34,7 +34,7 @@ python3 main.py
 ## 🚀 Características
 
 - **🔧 Auto-Install**: Instala tudo automaticamente
-- **🌐 Pronto para Produção**: Configurado para chatbot.auto-atendimento.digital
+- **🌐 Pronto para Produção**: Configurado para 78.46.250.112
 - **📱 WhatsApp Real**: Integração Baileys nativa
 - **🗄️ PostgreSQL**: Banco robusto e escalável
 - **⚡ Redis**: Cache e sessões
@@ -98,7 +98,7 @@ python3 main.py
 # - Instalar todas as dependências automaticamente
 # - Configurar PostgreSQL e Redis
 # - Iniciar todos os serviços
-# - Estar disponível em http://chatbot.auto-atendimento.digital:8000
+# - Estar disponível em http://78.46.250.112:8000
 ```
 
 ### 🔧 Instalação Manual (se necessário)

--- a/auto_install.py
+++ b/auto_install.py
@@ -349,8 +349,8 @@ sudo systemctl start whatsapp-bot-api
 sudo systemctl start whatsapp-bot-baileys
 
 echo "✅ Sistema iniciado!"
-echo "🌐 Acesse: http://chatbot.auto-atendimento.digital:8000"
-echo "📚 API Docs: http://chatbot.auto-atendimento.digital:8000/api/docs"
+echo "🌐 Acesse: http://78.46.250.112:8000"
+echo "📚 API Docs: http://78.46.250.112:8000/api/docs"
 echo "👤 Login: admin / admin123"
 """
     
@@ -364,7 +364,7 @@ def main():
     """Função principal de instalação"""
     print_status("🚀 INICIANDO INSTALAÇÃO AUTOMÁTICA", "HEADER")
     print_status("WhatsApp Bot Management System", "HEADER")
-    print_status("Domínio: chatbot.auto-atendimento.digital", "HEADER")
+    print_status("Domínio: 78.46.250.112", "HEADER")
     print_status("=" * 50, "HEADER")
     
     try:
@@ -406,8 +406,8 @@ def main():
         print_status("=" * 50, "SUCCESS")
         print_status("🎉 INSTALAÇÃO CONCLUÍDA COM SUCESSO!", "SUCCESS")
         print_status("=" * 50, "SUCCESS")
-        print_status("🌐 URL: http://chatbot.auto-atendimento.digital:8000", "SUCCESS")
-        print_status("📚 API: http://chatbot.auto-atendimento.digital:8000/api/docs", "SUCCESS")
+        print_status("🌐 URL: http://78.46.250.112:8000", "SUCCESS")
+        print_status("📚 API: http://78.46.250.112:8000/api/docs", "SUCCESS")
         print_status("👤 Login: admin / admin123", "SUCCESS")
         print_status("🔧 Para iniciar: ./start_system.sh", "SUCCESS")
         print_status("📋 Status: sudo systemctl status whatsapp-bot-*", "SUCCESS")

--- a/backend/server.py
+++ b/backend/server.py
@@ -351,7 +351,7 @@ async def read_root(request: Request):
                 </div>
                 
                 <div style="margin-top: 40px; text-align: center; color: #7f8c8d;">
-                    <p>🌐 Domain: chatbot.auto-atendimento.digital | 🚀 Powered by FastAPI</p>
+                    <p>🌐 Domain: 78.46.250.112 | 🚀 Powered by FastAPI</p>
                 </div>
             </div>
         </body>

--- a/deploy_whatsapp_bot.py
+++ b/deploy_whatsapp_bot.py
@@ -420,7 +420,7 @@ async def read_root(request: Request):
                 </div>
                 
                 <div style="margin-top: 40px; text-align: center; color: #7f8c8d;">
-                    <p>🌐 Domain: chatbot.auto-atendimento.digital | 🚀 Powered by FastAPI</p>
+                    <p>🌐 Domain: 78.46.250.112 | 🚀 Powered by FastAPI</p>
                 </div>
             </div>
         </body>

--- a/fix_deployment.py
+++ b/fix_deployment.py
@@ -166,7 +166,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES=1440
 ALGORITHM=HS256
 
 # Frontend Configuration
-FRONTEND_URL=http://chatbot.auto-atendimento.digital:8000
+FRONTEND_URL=http://78.46.250.112:8000
 
 # Baileys Service Configuration
 BAILEYS_SERVICE_URL=http://localhost:3001
@@ -250,8 +250,8 @@ echo "🔧 Iniciando aplicação FastAPI..."
 echo $! > fastapi.pid
 
 echo "✅ Sistema iniciado com sucesso!"
-echo "🌐 Acesse: http://chatbot.auto-atendimento.digital:8000"
-echo "📚 API Docs: http://chatbot.auto-atendimento.digital:8000/docs"
+echo "🌐 Acesse: http://78.46.250.112:8000"
+echo "📚 API Docs: http://78.46.250.112:8000/docs"
 
 # Keep script running
 wait
@@ -385,8 +385,8 @@ except ImportError as e:
             self.log("  OU", "INFO")
             self.log("  ./start_system.sh", "INFO")
             self.log("", "INFO")
-            self.log("🌐 URL: http://chatbot.auto-atendimento.digital:8000", "INFO")
-            self.log("📚 API: http://chatbot.auto-atendimento.digital:8000/docs", "INFO")
+            self.log("🌐 URL: http://78.46.250.112:8000", "INFO")
+            self.log("📚 API: http://78.46.250.112:8000/docs", "INFO")
             
         except Exception as e:
             self.log(f"Erro durante correção: {e}", "ERROR")

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # WhatsApp Bot Management System - Auto Installer
-# Domain: chatbot.auto-atendimento.digital
+# Domain: 78.46.250.112
 
 echo "🚀 WhatsApp Bot Management System"
-echo "🌐 Domain: chatbot.auto-atendimento.digital"
+echo "🌐 Domain: 78.46.250.112"
 echo "==============================================="
 
 # Colors
@@ -81,7 +81,7 @@ print_status "Configuring Nginx reverse proxy..."
 cat > /etc/nginx/sites-available/whatsapp-bot << 'EOF'
 server {
     listen 80;
-    server_name chatbot.auto-atendimento.digital;
+    server_name 78.46.250.112;
 
     location / {
         proxy_pass http://localhost:8000;
@@ -109,5 +109,5 @@ print_status "✅ System dependencies installed!"
 print_status "📁 Navigate to your project directory and run:"
 print_status "   python3 main.py"
 print_status ""
-print_status "🌐 Access: http://chatbot.auto-atendimento.digital"
+print_status "🌐 Access: http://78.46.250.112"
 print_status "👤 Login: admin / admin123"

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ def print_banner():
 ║                                                               ║
 ║          🤖 WhatsApp Bot Management System 🤖                ║
 ║                                                               ║
-║          🌐 Domain: chatbot.auto-atendimento.digital         ║
+║          🌐 Domain: 78.46.250.112         ║
 ║          🚀 Auto-Install & Auto-Start System                 ║
 ║                                                               ║
 ║          FastAPI + PostgreSQL + Baileys + React              ║
@@ -260,9 +260,9 @@ def start_services():
         print_status("=" * 60, "SUCCESS")
         print_status("🎉 SISTEMA INICIADO COM SUCESSO!", "SUCCESS")
         print_status("=" * 60, "SUCCESS")
-        print_status("🌐 URL Principal: http://chatbot.auto-atendimento.digital:8000", "SUCCESS")
-        print_status("📚 API Docs: http://chatbot.auto-atendimento.digital:8000/api/docs", "SUCCESS")
-        print_status("🤖 Baileys API: http://chatbot.auto-atendimento.digital:3001", "SUCCESS")
+        print_status("🌐 URL Principal: http://78.46.250.112:8000", "SUCCESS")
+        print_status("📚 API Docs: http://78.46.250.112:8000/api/docs", "SUCCESS")
+        print_status("🤖 Baileys API: http://78.46.250.112:3001", "SUCCESS")
         print_status("👤 Login Padrão: admin / admin123", "SUCCESS")
         print_status("⚠️  ALTERE A SENHA APÓS PRIMEIRO LOGIN!", "WARNING")
         print_status("=" * 60, "SUCCESS")
@@ -367,7 +367,7 @@ def create_app():
                 "status": "healthy",
                 "service": "whatsapp-bot-api",
                 "version": "1.0.0",
-                "domain": "chatbot.auto-atendimento.digital"
+                "domain": "78.46.250.112"
             }
         
         return app

--- a/services/instance_service.py
+++ b/services/instance_service.py
@@ -36,7 +36,7 @@ class InstanceService:
         
         # Create WhatsApp session
         try:
-            webhook_url = f"http://chatbot.auto-atendimento.digital:8000/api/webhook/whatsapp/{db_instance.id}"
+            webhook_url = f"http://78.46.250.112:8000/api/webhook/whatsapp/{db_instance.id}"
             await whatsapp_service.create_session(session_id, webhook_url)
         except Exception as e:
             # If session creation fails, update status to error

--- a/start.py.backup
+++ b/start.py.backup
@@ -116,7 +116,7 @@ async def root(request: Request):
     if os.path.exists("templates/index.html"):
         return templates.TemplateResponse("index.html", {"request": request})
     else:
-        return {"message": "WhatsApp Bot System", "status": "running", "domain": "chatbot.auto-atendimento.digital"}
+        return {"message": "WhatsApp Bot System", "status": "running", "domain": "78.46.250.112"}
 
 @app.get("/health")
 async def health():
@@ -134,7 +134,7 @@ if __name__ == "__main__":
 
 def main():
     print_msg("🤖 WhatsApp Bot - Start Script", "INFO")
-    print_msg("🌐 Domain: chatbot.auto-atendimento.digital", "INFO")
+    print_msg("🌐 Domain: 78.46.250.112", "INFO")
     print_msg("=" * 50, "INFO")
     
     # 1. Instalar dependências

--- a/start_domain_server.py
+++ b/start_domain_server.py
@@ -14,6 +14,6 @@ from backend.server import app
 
 if __name__ == "__main__":
     import uvicorn
-    print("🌐 Iniciando WhatsApp Bot Management System em http://chatbot.auto-atendimento.digital:8000")
+    print("🌐 Iniciando WhatsApp Bot Management System em http://78.46.250.112:8000")
     print("🚀 Sistema pronto para acesso pelo domínio!")
     uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info")

--- a/start_system.sh
+++ b/start_system.sh
@@ -14,6 +14,6 @@ sudo systemctl start whatsapp-bot-api
 sudo systemctl start whatsapp-bot-baileys
 
 echo "✅ Sistema iniciado!"
-echo "🌐 Acesse: http://chatbot.auto-atendimento.digital:8000"
-echo "📚 API Docs: http://chatbot.auto-atendimento.digital:8000/api/docs"
+echo "🌐 Acesse: http://78.46.250.112:8000"
+echo "📚 API Docs: http://78.46.250.112:8000/api/docs"
 echo "👤 Login: admin / admin123"

--- a/static/app.js
+++ b/static/app.js
@@ -4,7 +4,7 @@ let authToken = null;
 
 // API configuration
 const API_BASE = '/api';
-const DOMAIN = 'chatbot.auto-atendimento.digital';
+const DOMAIN = '78.46.250.112';
 
 // Initialize app
 document.addEventListener('DOMContentLoaded', function() {

--- a/test_result.md
+++ b/test_result.md
@@ -102,7 +102,7 @@
 # Testing Data - Main Agent and testing sub agent both should log testing data below this section
 #====================================================================================================
 
-user_problem_statement: "Sistema de gestão WhatsApp Bot em HTML com bugs + requisitos: transformar em sistema executável para servidor SSH (chatbot.auto-atendimento.digital), auto-instalar dependências, funcionar com PostgreSQL + Baileys WhatsApp, executar tudo com python main.py"
+user_problem_statement: "Sistema de gestão WhatsApp Bot em HTML com bugs + requisitos: transformar em sistema executável para servidor SSH (78.46.250.112), auto-instalar dependências, funcionar com PostgreSQL + Baileys WhatsApp, executar tudo com python main.py"
 
 frontend:
   - task: "Corrigir bugs JavaScript no sistema HTML"
@@ -185,7 +185,7 @@ agent_communication:
     message: "🎉 COMPREHENSIVE BACKEND TESTING COMPLETED - 100% SUCCESS RATE! Tested all 7 core API endpoints with perfect results: Health check, Authentication (login/me), Dashboard stats, WhatsApp instances (list/create), Messages (list/send), Campaigns (list/create), and Finances. All endpoints returning proper JSON responses with correct data structures. Authentication flow working with admin/admin123 credentials. System is production-ready and fully functional at https://chatops-control.preview.emergentagent.com/api. Detailed test results saved to /app/test_results_backend.json."
 
 final_system_summary:
-  domain: "chatbot.auto-atendimento.digital"
+  domain: "78.46.250.112"
   server_ip: "78.46.250.112" 
   execution_command: "python3 main.py"
   auto_install: true
@@ -209,8 +209,8 @@ final_system_summary:
     - "Configurado para produção"
   
   access_urls:
-    - "http://chatbot.auto-atendimento.digital:8000 (Interface)"
-    - "http://chatbot.auto-atendimento.digital:8000/api/docs (API)"
+    - "http://78.46.250.112:8000 (Interface)"
+    - "http://78.46.250.112:8000/api/docs (API)"
     - "Login: admin / admin123"
 
 backend:


### PR DESCRIPTION
## Summary
- replace domain references with the server IP `78.46.250.112` across backend responses, scripts, and documentation
- align frontend configuration and webhook URLs with the new host

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca22665950832b937dd3f561412a12